### PR TITLE
Implemented reference time parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ examples supported as of version 0.1.5:
 
 ## Configuration
 
+### Non-ignorable errors
+
 Errors emitted by the extension are non-ignorable by default, so they cannot accidentally be put into the baseline.
 You can change this behaviour with a configuration option within your `phpstan.neon`:
 
@@ -57,6 +59,29 @@ parameters:
     todo_by:
         nonIgnorable: false # default is true
 ```
+
+### Reference time
+
+By default comments are checked against todays date.
+
+You might be interested, which comments will expire within the next 7 days or similar, which can be configured with the `referenceTime` option.
+You need to configure a date parsable by `strtotime`.
+
+```neon
+parameters:
+    todo_by:
+        referenceTime: "now+7days"
+```
+
+It can be especially handy to use a env variable for it, so you can pass the reference date e.g. via the CLI:
+
+```neon
+parameters:
+    todo_by:
+        referenceTime: %env.TODOBY_REF_TIME%
+```
+
+`TODOBY_REF_TIME="now+7days" vendor/bin/phpstan analyze`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ parameters:
 
 By default comments are checked against todays date.
 
-You might be interested, which comments will expire within the next 7 days or similar, which can be configured with the `referenceTime` option.
+You might be interested, which comments will expire e.g. within the next 7 days, which can be configured with the `referenceTime` option.
 You need to configure a date parsable by `strtotime`.
 
 ```neon

--- a/extension.neon
+++ b/extension.neon
@@ -16,3 +16,4 @@ services:
         tags: [phpstan.rules.rule]
         arguments:
             - %todo_by.nonIgnorable%
+            - %todo_by.referenceTime%

--- a/extension.neon
+++ b/extension.neon
@@ -1,12 +1,14 @@
 parametersSchema:
     todo_by: structure([
         nonIgnorable: bool()
+        referenceTime: string()
     ])
 
 # default parameters
 parameters:
     todo_by:
         nonIgnorable: true
+        referenceTime: "now"
 
 services:
     -

--- a/src/TodoByRule.php
+++ b/src/TodoByRule.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\VirtualNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
 use function preg_match_all;
 use function strtotime;
 use function substr_count;
@@ -36,7 +37,13 @@ REGEXP;
 
     public function __construct(bool $nonIgnorable, string $referenceTime)
     {
-        $this->now = strtotime($referenceTime);
+        $time =  strtotime($referenceTime);
+
+        if ($time === false) {
+            throw new \RuntimeException('Unable to parse reference time "' . $referenceTime . '"');
+        }
+
+        $this->now = $time;
         $this->nonIgnorable = $nonIgnorable;
     }
 

--- a/src/TodoByRule.php
+++ b/src/TodoByRule.php
@@ -34,9 +34,9 @@ REGEXP;
     private int $now;
     private bool $nonIgnorable;
 
-    public function __construct(bool $nonIgnorable)
+    public function __construct(bool $nonIgnorable, string $referenceTime)
     {
-        $this->now = time();
+        $this->now = strtotime($referenceTime);
         $this->nonIgnorable = $nonIgnorable;
     }
 

--- a/tests/TodoByRuleTest.php
+++ b/tests/TodoByRuleTest.php
@@ -11,13 +11,16 @@ use staabm\PHPStanTodoBy\TodoByRule;
  */
 final class TodoByRuleTest extends RuleTestCase
 {
+    private string $referenceTime;
     protected function getRule(): Rule
     {
-        return new TodoByRule(true);
+        return new TodoByRule(true, $this->referenceTime);
     }
 
     public function testRule(): void
     {
+        $this->referenceTime = "now";
+
         $this->analyse([__DIR__ . '/data/example.php'], [
             [
                 'Expired on 2023-12-14: Expired comment1',
@@ -102,6 +105,25 @@ final class TodoByRuleTest extends RuleTestCase
             [
                 'Expired on 2023-12-14: classic multi line comment',
                 59,
+            ],
+        ]);
+    }
+
+    public function testReferenceTime(): void
+    {
+        $this->referenceTime = "1st january 2023";
+
+        $this->analyse([__DIR__ . '/data/referenceTime.php'], []);
+    }
+
+    public function testReferenceTime2(): void
+    {
+        $this->referenceTime = "18th january 2023";
+
+        $this->analyse([__DIR__ . '/data/referenceTime.php'], [
+            [
+                'Expired on 2023-01-14: fix it',
+                5,
             ],
         ]);
     }

--- a/tests/data/referenceTime.php
+++ b/tests/data/referenceTime.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ExpiryOffset;
+
+// todo - 2023-01-14 fix it
+

--- a/tests/data/referenceTime.php
+++ b/tests/data/referenceTime.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ExpiryOffset;
+namespace ReferenceTime;
 
 // todo - 2023-01-14 fix it
 


### PR DESCRIPTION
By default comments are checked against todays date.

You might be interested, which comments will expire e.g. within the next 7 days, which can be configured with the `referenceTime` option.
You need to configure a date parsable by `strtotime`.

```neon
parameters:
    todo_by:
        referenceTime: "now+7days"
```

It can be especially handy to use a env variable for it, so you can pass the reference date e.g. via the CLI:

```neon
parameters:
    todo_by:
        referenceTime: %env.TODOBY_REF_TIME%
```

`TODOBY_REF_TIME="now+7days" vendor/bin/phpstan analyze`