### PR TITLE
Implement TodoByVersionRule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+/.github export-ignore
 /tests export-ignore
+.editorconfig export-ignore
 phpstan.neon export-ignore

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,6 +30,9 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v4
 
+            -   name: Get tags
+                run: git fetch --tags origin
+
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,6 +27,9 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v4
 
+            -   name: Get tags
+                run: git fetch --tags origin
+
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ parameters:
 
 As shown in the "Reference time"-paragraph above, you might even use a env variable instead.
 
+Make sure tags are available within your git clone, e.g. by running `git fetch --tags origin`.
+
+In a GitHub Action this can be done like this:
+
+```yaml
+    -   name: Checkout
+        uses: actions/checkout@v4
+
+    -   name: Get tags
+        run: git fetch --tags origin
+```
+
 ## Installation
 
 To use this extension, require it in [Composer](https://getcomposer.org/):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# phpstan-todo-by: comments with expiration date
+# phpstan-todo-by: comments with expiration date/version
 
-PHPStan extension to check for TODO comments with expiration date.
+PHPStan extension to check for TODO comments with expiration date/version.
 Inspired by [parker-codes/todo-by](https://github.com/parker-codes/todo_by).
 
 ## Example:
@@ -10,6 +10,11 @@ Inspired by [parker-codes/todo-by](https://github.com/parker-codes/todo_by).
 
 // TODO: 2023-12-14 This comment turns into a PHPStan error as of 14th december 2023
 function doFoo() {
+
+}
+
+// TODO: <1.0.0 This has to be in the first major release
+function doBar() {
 
 }
 
@@ -45,6 +50,9 @@ examples supported as of version 0.1.5:
  * @todo 2023-12-14 classic multi line comment
  *   more comment data
  */
+
+// TODO: <1.0.0 This has to be in the first major release
+// TODO >123.4: Must fix this or bump the version
 ```
 
 ## Configuration
@@ -62,7 +70,7 @@ parameters:
 
 ### Reference time
 
-By default comments are checked against todays date.
+By default date-todo-comments are checked against todays date.
 
 You might be interested, which comments will expire e.g. within the next 7 days, which can be configured with the `referenceTime` option.
 You need to configure a date parsable by `strtotime`.
@@ -70,6 +78,7 @@ You need to configure a date parsable by `strtotime`.
 ```neon
 parameters:
     todo_by:
+        # any strtotime() compatible string
         referenceTime: "now+7days"
 ```
 
@@ -82,6 +91,23 @@ parameters:
 ```
 
 `TODOBY_REF_TIME="now+7days" vendor/bin/phpstan analyze`
+
+### Reference version
+
+By default version-todo-comments are checked against `"nextMajor"` version.
+This is determined by fetching the latest local available git tag and incrementing the major version number.
+
+This behaviour can be configured with the `referenceVersion` option.
+Possible values are `"nextMajor"`, `"nextMinor"`, `"nextPatch"` - which will be computed based on the latest local git tag - or any other version string like `"1.2.3"`.
+
+```neon
+parameters:
+    todo_by:
+        # "nextMajor", "nextMinor", "nextPatch" or a version string like "1.2.3"
+        referenceVersion: "nextMinor"
+```
+
+As shown in the "Reference time"-paragraph above, you might even use a env variable instead.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "keywords": ["dev", "phpstan", "phpstan-extension", "static analysis"],
 
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.4 || ^8.0",
+        "composer/semver": "^3.4"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 
     "require": {
         "php": "^7.4 || ^8.0",
-        "composer/semver": "^3.4"
+        "composer/semver": "^3.4",
+        "nikolaposa/version": "^4.1"
     },
 
     "require-dev": {

--- a/extension.neon
+++ b/extension.neon
@@ -2,13 +2,19 @@ parametersSchema:
     todo_by: structure([
         nonIgnorable: bool()
         referenceTime: string()
+        referenceVersion: string()
     ])
 
 # default parameters
 parameters:
     todo_by:
         nonIgnorable: true
+
+        # any strtotime() compatible string
         referenceTime: "now"
+
+        # "nextMajor", "nextMinor", "nextPatch" or a version string like "1.2.3"
+        referenceVersion: "nextMajor"
 
 services:
     -
@@ -17,3 +23,17 @@ services:
         arguments:
             - %todo_by.nonIgnorable%
             - %todo_by.referenceTime%
+
+    -
+        class: staabm\PHPStanTodoBy\TodoByVersionRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            - %todo_by.nonIgnorable%
+
+    -
+        class: staabm\PHPStanTodoBy\GitTagFetcher
+
+    -
+        class: staabm\PHPStanTodoBy\ReferenceVersionFinder
+        arguments:
+            - %todo_by.referenceVersion%

--- a/src/GitTagFetcher.php
+++ b/src/GitTagFetcher.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace staabm\PHPStanTodoBy;
+
+final class GitTagFetcher {
+    // fetch version of the latest created git tag
+    public function fetchLatestTagVersion(): string
+    {
+        exec('git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/"', $output, $returnCode);
+        if ($returnCode !== 0 || count($output) !== 1) {
+            throw new \RuntimeException('Could not determine latest git tag');
+        }
+        return $output[0];
+    }
+}

--- a/src/ReferenceVersionFinder.php
+++ b/src/ReferenceVersionFinder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace staabm\PHPStanTodoBy;
+
+use Version\Version;
+
+final class ReferenceVersionFinder {
+    private GitTagFetcher $fetcher;
+    private string $referenceVersion;
+
+    public function __construct(string $referenceVersion, GitTagFetcher $fetcher) {
+        $this->referenceVersion = $referenceVersion;
+        $this->fetcher = $fetcher;
+    }
+    public function find(): string {
+        if (in_array($this->referenceVersion, ['nextMajor', 'nextMinor', 'nextPatch'], true)) {
+            $latestTagVersion = $this->fetcher->fetchLatestTagVersion();
+
+            $version = Version::fromString($latestTagVersion);
+            if ($this->referenceVersion === 'nextMajor') {
+                return $version->incrementMajor()->toString();
+            }
+            if ($this->referenceVersion === 'nextMinor') {
+                return $version->incrementMinor()->toString();
+            }
+            if ($this->referenceVersion === 'nextPatch') {
+                return $version->incrementPatch()->toString();
+            }
+        }
+
+        // a version string like "1.2.3"
+        return $this->referenceVersion;
+    }
+}

--- a/src/TodoByVersionRule.php
+++ b/src/TodoByVersionRule.php
@@ -49,19 +49,6 @@ REGEXP;
         $this->nonIgnorable = $nonIgnorable;
     }
 
-    private function getVersionComparator(string $version): ?string {
-        $comparator = null;
-        for($i = 0; $i < strlen($version); $i++) {
-            if (!in_array($version[$i], self::COMPARATORS)) {
-                break;
-            }
-            $comparator .= $version[$i];
-        }
-
-        return $comparator;
-
-    }
-
     public function getNodeType(): string
     {
         return Node::class;
@@ -141,5 +128,18 @@ REGEXP;
         }
 
         return $errors;
+    }
+
+    private function getVersionComparator(string $version): ?string {
+        $comparator = null;
+        for($i = 0; $i < strlen($version); $i++) {
+            if (!in_array($version[$i], self::COMPARATORS)) {
+                break;
+            }
+            $comparator .= $version[$i];
+        }
+
+        return $comparator;
+
     }
 }

--- a/src/TodoByVersionRule.php
+++ b/src/TodoByVersionRule.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace staabm\PHPStanTodoBy;
+
+use Composer\Semver\Comparator;
+use Composer\Semver\VersionParser;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\VirtualNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+use function preg_match_all;
+use function strtotime;
+use function substr_count;
+use function time;
+use function trim;
+use const PREG_OFFSET_CAPTURE;
+use const PREG_SET_ORDER;
+
+/**
+ * @implements Rule<Node>
+ */
+final class TodoByVersionRule implements Rule
+{
+    private const COMPARATORS = ['<', '>', '='];
+
+    private const PATTERN = <<<'REGEXP'
+/
+@?TODO # possible @ prefix
+@?[a-zA-Z0-9_-]*\s* # optional username
+\s*[:-]?\s* # optional colon or hyphen
+(?P<version>[<>=]+[^\s:\-]+) # version
+\s*[:-]?\s* # optional colon or hyphen
+(?P<comment>.*) # rest of line as comment text
+/ix
+REGEXP;
+
+    private string $referenceVersion;
+    private bool $nonIgnorable;
+
+    private VersionParser $versionParser;
+
+    public function __construct(bool $nonIgnorable, string $referenceVersion)
+    {
+        $this->versionParser = new VersionParser();
+
+        $this->referenceVersion = $this->versionParser->normalize($referenceVersion);
+        $this->nonIgnorable = $nonIgnorable;
+    }
+
+    private function getVersionComparator(string $version): ?string {
+        $comparator = null;
+        for($i = 0; $i < strlen($version); $i++) {
+            if (!in_array($version[$i], self::COMPARATORS)) {
+                break;
+            }
+            $comparator .= $version[$i];
+        }
+
+        return $comparator;
+
+    }
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (
+            $node instanceof VirtualNode
+            || $node instanceof Node\Expr
+        ) {
+            // prevent duplicate errors
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->getComments() as $comment) {
+
+            $text = $comment->getText();
+
+            /**
+             * PHP doc comments have the entire multi-line comment as the text.
+             * Since this could potentially contain multiple "todo" comments, we need to check all lines.
+             * This works for single line comments as well.
+             *
+             * PREG_OFFSET_CAPTURE: Track where each "todo" comment starts within the whole comment text.
+             * PREG_SET_ORDER: Make each value of $matches be structured the same as if from preg_match().
+             */
+            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === FALSE) {
+                continue;
+            }
+
+            /** @var array<int, array<array{0: string, 1: int}>> $matches */
+            foreach ($matches as $match) {
+
+                $version = $match['version'][0];
+                $todoText = trim($match['comment'][0]);
+
+                $versionComparator = $this->getVersionComparator($version);
+                $plainVersion = ltrim($version, implode("", self::COMPARATORS));
+                $normalized = $this->versionParser->normalize($plainVersion);
+
+                $expired = false;
+                if ($versionComparator === '<') {
+                    $expired = Comparator::greaterThanOrEqualTo($this->referenceVersion, $normalized);
+                } elseif ($versionComparator === '>') {
+                    $expired = Comparator::greaterThan($this->referenceVersion, $normalized);
+                }
+
+                if (!$expired) {
+                    continue;
+                }
+
+                // Have always present date at the start of the message.
+                // If there is further text, append it.
+                if ($todoText !== '') {
+                    $errorMessage = "Version requirement {$version} not satisfied: {$todoText}";
+                } else {
+                    $errorMessage = "Version requirement {$version} not satisfied";
+                }
+
+                $wholeMatchStartOffset = $match[0][1];
+
+                // Count the number of newlines between the start of the whole comment, and the start of the match.
+                $newLines = substr_count($text, "\n", 0, $wholeMatchStartOffset);
+
+                // Set the message line to match the line the comment actually starts on.
+                $messageLine = $comment->getStartLine() + $newLines;
+
+                $errBuilder = RuleErrorBuilder::message($errorMessage)->line($messageLine);
+                if ($this->nonIgnorable) {
+                    $errBuilder->nonIgnorable();
+                }
+                $errors[] = $errBuilder->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/TodoByVersionRuleTest.php
+++ b/tests/TodoByVersionRuleTest.php
@@ -100,6 +100,9 @@ final class TodoByVersionRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/version.php'], $errors);
     }
 
+    /**
+     * @return iterable<array{string, list<array{0: string, 1: int, 2?: string|null}>}>
+     */
     static public function provideSemanticVersions(): iterable {
         yield [
             'nextMajor', // we assume this resolves to 1.0

--- a/tests/TodoByVersionRuleTest.php
+++ b/tests/TodoByVersionRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace staabm\PHPStanTodoBy\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use staabm\PHPStanTodoBy\TodoByDateRule;
+use staabm\PHPStanTodoBy\TodoByVersionRule;
+
+/**
+ * @extends RuleTestCase<TodoByVersionRule>
+ */
+final class TodoByVersionRuleTest extends RuleTestCase
+{
+    private string $referenceVersion;
+    protected function getRule(): Rule
+    {
+        return new TodoByVersionRule(true, $this->referenceVersion);
+    }
+
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $errors
+     * @dataProvider provideErrors
+     */
+    public function testRule(string $referenceVersion, array $errors): void
+    {
+        $this->referenceVersion = $referenceVersion;
+
+        $this->analyse([__DIR__ . '/data/version.php'], $errors);
+    }
+
+    /**
+     * @return iterable<array{string, list<array{0: string, 1: int, 2?: string|null}>}>
+     */
+    static public function provideErrors(): iterable
+    {
+        yield [
+            "0.1",
+            [
+            ]
+        ];
+
+        yield [
+            "1.0",
+            [
+                [
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    5,
+                ],
+                [
+                'Version requirement <1.0.0 not satisfied',
+                    10,
+                ]
+            ]
+        ];
+
+        yield [
+            "123.4",
+            [
+                [
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    5,
+                ],
+                [
+                    'Version requirement <1.0.0 not satisfied',
+                    10,
+                ]
+            ]
+        ];
+
+        yield [
+            "123.5",
+            [
+                [
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    5,
+                ],
+                [
+                    'Version requirement >123.4 not satisfied: Must fix this or bump the version',
+                    7,
+                ],
+                [
+                    'Version requirement <1.0.0 not satisfied',
+                    10,
+                ]
+            ]
+        ];
+    }
+
+}

--- a/tests/TodoByVersionRuleTest.php
+++ b/tests/TodoByVersionRuleTest.php
@@ -4,6 +4,8 @@ namespace staabm\PHPStanTodoBy\Tests;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use staabm\PHPStanTodoBy\GitTagFetcher;
+use staabm\PHPStanTodoBy\ReferenceVersionFinder;
 use staabm\PHPStanTodoBy\TodoByDateRule;
 use staabm\PHPStanTodoBy\TodoByVersionRule;
 
@@ -15,7 +17,7 @@ final class TodoByVersionRuleTest extends RuleTestCase
     private string $referenceVersion;
     protected function getRule(): Rule
     {
-        return new TodoByVersionRule(true, $this->referenceVersion);
+        return new TodoByVersionRule(true, new ReferenceVersionFinder($this->referenceVersion, new GitTagFetcher()));
     }
 
     /**
@@ -44,11 +46,11 @@ final class TodoByVersionRuleTest extends RuleTestCase
             "1.0",
             [
                 [
-                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release.',
                     5,
                 ],
                 [
-                'Version requirement <1.0.0 not satisfied',
+                'Version requirement <1.0.0 not satisfied.',
                     10,
                 ]
             ]
@@ -58,11 +60,11 @@ final class TodoByVersionRuleTest extends RuleTestCase
             "123.4",
             [
                 [
-                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release.',
                     5,
                 ],
                 [
-                    'Version requirement <1.0.0 not satisfied',
+                    'Version requirement <1.0.0 not satisfied.',
                     10,
                 ]
             ]
@@ -72,15 +74,42 @@ final class TodoByVersionRuleTest extends RuleTestCase
             "123.5",
             [
                 [
-                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release',
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release.',
                     5,
                 ],
                 [
-                    'Version requirement >123.4 not satisfied: Must fix this or bump the version',
+                    'Version requirement >123.4 not satisfied: Must fix this or bump the version.',
                     7,
                 ],
                 [
-                    'Version requirement <1.0.0 not satisfied',
+                    'Version requirement <1.0.0 not satisfied.',
+                    10,
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $errors
+     * @dataProvider provideSemanticVersions
+     */
+    public function testSemanticVersions(string $referenceVersion, array $errors): void
+    {
+        $this->referenceVersion = $referenceVersion;
+
+        $this->analyse([__DIR__ . '/data/version.php'], $errors);
+    }
+
+    static public function provideSemanticVersions(): iterable {
+        yield [
+            'nextMajor', // we assume this resolves to 1.0
+            [
+                [
+                    'Version requirement <1.0.0 not satisfied: This has to be in the first major release.',
+                    5,
+                ],
+                [
+                    'Version requirement <1.0.0 not satisfied.',
                     10,
                 ]
             ]

--- a/tests/data/version.php
+++ b/tests/data/version.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ExampleVersion;
+
+// TODO: <1.0.0 This has to be in the first major release
+function doFoo():void {
+    // TODO >123.4: Must fix this or bump the version
+}
+
+// TODO: <1.0.0


### PR DESCRIPTION
### Reference version

By default version-todo-comments are checked against `"nextMajor"` version.
This is determined by fetching the latest local available git tag and incrementing the major version number.

This behaviour can be configured with the `referenceVersion` option.
Possible values are `"nextMajor"`, `"nextMinor"`, `"nextPatch"` - which will be computed based on the latest local git tag - or any other version string like `"1.2.3"`.

```neon
parameters:
    todo_by:
        # "nextMajor", "nextMinor", "nextPatch" or a version string like "1.2.3"
        referenceVersion: "nextMinor"
```

Make sure tags are available within your git clone, e.g. by running `git fetch --tags origin`.

In a GitHub Action this can be done like this:

```yaml
    -   name: Checkout
        uses: actions/checkout@v4

    -   name: Get tags
        run: git fetch --tags origin
```

closes https://github.com/staabm/phpstan-todo-by/issues/6