### PR TITLE
Fix laziness of TagFetcher

### DIFF
--- a/src/GitTagFetcher.php
+++ b/src/GitTagFetcher.php
@@ -2,7 +2,7 @@
 
 namespace staabm\PHPStanTodoBy;
 
-final class GitTagFetcher {
+final class GitTagFetcher implements TagFetcher {
     // fetch version of the latest created git tag
     public function fetchLatestTagVersion(): string
     {

--- a/src/ReferenceVersionFinder.php
+++ b/src/ReferenceVersionFinder.php
@@ -5,10 +5,10 @@ namespace staabm\PHPStanTodoBy;
 use Version\Version;
 
 final class ReferenceVersionFinder {
-    private GitTagFetcher $fetcher;
+    private TagFetcher $fetcher;
     private string $referenceVersion;
 
-    public function __construct(string $referenceVersion, GitTagFetcher $fetcher) {
+    public function __construct(string $referenceVersion, TagFetcher $fetcher) {
         $this->referenceVersion = $referenceVersion;
         $this->fetcher = $fetcher;
     }

--- a/src/TagFetcher.php
+++ b/src/TagFetcher.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace staabm\PHPStanTodoBy;
+
+interface TagFetcher
+{
+    public function fetchLatestTagVersion(): string;
+}

--- a/src/TodoByDateRule.php
+++ b/src/TodoByDateRule.php
@@ -76,7 +76,10 @@ REGEXP;
              * PREG_OFFSET_CAPTURE: Track where each "todo" comment starts within the whole comment text.
              * PREG_SET_ORDER: Make each value of $matches be structured the same as if from preg_match().
              */
-            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) !== 1) {
+            if (
+                preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === FALSE
+                || count($matches) === 0
+            ) {
                 continue;
             }
 

--- a/src/TodoByDateRule.php
+++ b/src/TodoByDateRule.php
@@ -76,7 +76,7 @@ REGEXP;
              * PREG_OFFSET_CAPTURE: Track where each "todo" comment starts within the whole comment text.
              * PREG_SET_ORDER: Make each value of $matches be structured the same as if from preg_match().
              */
-            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === FALSE) {
+            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) !== 1) {
                 continue;
             }
 

--- a/src/TodoByVersionRule.php
+++ b/src/TodoByVersionRule.php
@@ -79,7 +79,10 @@ REGEXP;
              * PREG_OFFSET_CAPTURE: Track where each "todo" comment starts within the whole comment text.
              * PREG_SET_ORDER: Make each value of $matches be structured the same as if from preg_match().
              */
-            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) !== 1) {
+            if (
+                preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === FALSE
+                || count($matches) === 0
+            ) {
                 continue;
             }
 

--- a/src/TodoByVersionRule.php
+++ b/src/TodoByVersionRule.php
@@ -79,7 +79,7 @@ REGEXP;
              * PREG_OFFSET_CAPTURE: Track where each "todo" comment starts within the whole comment text.
              * PREG_SET_ORDER: Make each value of $matches be structured the same as if from preg_match().
              */
-            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === FALSE) {
+            if (preg_match_all(self::PATTERN, $text, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) !== 1) {
                 continue;
             }
 

--- a/tests/AlwaysThrowingTagFetcher.php
+++ b/tests/AlwaysThrowingTagFetcher.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace staabm\PHPStanTodoBy\Tests;
+
+use staabm\PHPStanTodoBy\TagFetcher;
+
+final class AlwaysThrowingTagFetcher implements TagFetcher {
+    public function fetchLatestTagVersion(): string
+    {
+        throw new \RuntimeException('Could not determine latest git tag');
+    }
+}

--- a/tests/TodoByVersionRuleAlwaysThrowingFetchterTest.php
+++ b/tests/TodoByVersionRuleAlwaysThrowingFetchterTest.php
@@ -10,7 +10,7 @@ use staabm\PHPStanTodoBy\TodoByVersionRule;
 /**
  * @extends RuleTestCase<TodoByVersionRule>
  */
-final class TodoByVersionRuleThrowingFetchterTest extends RuleTestCase
+final class TodoByVersionRuleAlwaysThrowingFetchterTest extends RuleTestCase
 {
     private string $referenceVersion;
     protected function getRule(): Rule

--- a/tests/TodoByVersionRuleThrowingFetchterTest.php
+++ b/tests/TodoByVersionRuleThrowingFetchterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace staabm\PHPStanTodoBy\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use staabm\PHPStanTodoBy\ReferenceVersionFinder;
+use staabm\PHPStanTodoBy\TodoByVersionRule;
+
+/**
+ * @extends RuleTestCase<TodoByVersionRule>
+ */
+final class TodoByVersionRuleThrowingFetchterTest extends RuleTestCase
+{
+    private string $referenceVersion;
+    protected function getRule(): Rule
+    {
+        return new TodoByVersionRule(true, new ReferenceVersionFinder($this->referenceVersion, new AlwaysThrowingTagFetcher()));
+    }
+
+    public function testRule(): void
+    {
+        $this->referenceVersion = "0.1";
+
+        $this->analyse([__DIR__ . '/data/regularComments.php'], []);
+    }
+
+}

--- a/tests/TodoByVersionRuleThrowingFetchterTest.php
+++ b/tests/TodoByVersionRuleThrowingFetchterTest.php
@@ -20,7 +20,7 @@ final class TodoByVersionRuleThrowingFetchterTest extends RuleTestCase
 
     public function testRule(): void
     {
-        $this->referenceVersion = "0.1";
+        $this->referenceVersion = "nextMajor";
 
         $this->analyse([__DIR__ . '/data/regularComments.php'], []);
     }

--- a/tests/data/regularComments.php
+++ b/tests/data/regularComments.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace RegularComments;
+
+// a file comment
+
+/**
+ * @return void
+ */
+function doFoo() {
+    // inner function comment
+    $x = 1;
+}


### PR DESCRIPTION
before this PR we did not properly skip further processing after matching comments.
a empty search-result was still processed and therefore the git fetcher was triggered unintentionally.

closes https://github.com/staabm/phpstan-todo-by/issues/14