### PR TITLE
Support less strict versioning schemes

### DIFF
--- a/src/ReferenceVersionFinder.php
+++ b/src/ReferenceVersionFinder.php
@@ -26,7 +26,11 @@ final class ReferenceVersionFinder
                 try {
                     $version = Version::fromString($latestTagVersion.'.0');
                 } catch (InvalidVersionString $innerException) {
-                    throw $originException;
+                    try {
+                        $version = Version::fromString($latestTagVersion.'.0.0');
+                    } catch (InvalidVersionString $innerInnerException) {
+                        throw $originException;
+                    }
                 }
             }
 

--- a/src/ReferenceVersionFinder.php
+++ b/src/ReferenceVersionFinder.php
@@ -2,6 +2,7 @@
 
 namespace staabm\PHPStanTodoBy;
 
+use Version\Exception\InvalidVersionString;
 use Version\Version;
 
 final class ReferenceVersionFinder
@@ -19,7 +20,16 @@ final class ReferenceVersionFinder
         if (in_array($this->referenceVersion, ['nextMajor', 'nextMinor', 'nextPatch'], true)) {
             $latestTagVersion = $this->fetcher->fetchLatestTagVersion();
 
-            $version = Version::fromString($latestTagVersion);
+            try {
+                $version = Version::fromString($latestTagVersion);
+            } catch (InvalidVersionString $originException) {
+                try {
+                    $version = Version::fromString($latestTagVersion.'.0');
+                } catch (InvalidVersionString $innerException) {
+                    throw $originException;
+                }
+            }
+            
             if ($this->referenceVersion === 'nextMajor') {
                 return $version->incrementMajor()->toString();
             }

--- a/src/ReferenceVersionFinder.php
+++ b/src/ReferenceVersionFinder.php
@@ -29,7 +29,7 @@ final class ReferenceVersionFinder
                     throw $originException;
                 }
             }
-            
+
             if ($this->referenceVersion === 'nextMajor') {
                 return $version->incrementMajor()->toString();
             }

--- a/tests/ReferenceVersionFinderTest.php
+++ b/tests/ReferenceVersionFinderTest.php
@@ -22,6 +22,13 @@ final class ReferenceVersionFinderTest extends TestCase
     static public function provideData(): iterable
     {
         yield [
+            '1.2.3',
+            '1.0.3',
+            '1.2.3',
+        ];
+
+
+        yield [
             'nextMajor',
             '1.0.3',
             '2.0.0',

--- a/tests/ReferenceVersionFinderTest.php
+++ b/tests/ReferenceVersionFinderTest.php
@@ -62,17 +62,17 @@ final class ReferenceVersionFinderTest extends TestCase
 
         yield [
             'nextMajor',
-            '1.0',
+            '1',
             '2.0.0',
         ];
         yield [
             'nextMinor',
-            '1.0',
+            '1',
             '1.1.0',
         ];
         yield [
             'nextPatch',
-            '1.0',
+            '1',
             '1.0.1',
         ];
     }

--- a/tests/ReferenceVersionFinderTest.php
+++ b/tests/ReferenceVersionFinderTest.php
@@ -19,6 +19,9 @@ final class ReferenceVersionFinderTest extends TestCase
         $this->assertSame($expected, $finder->find());
     }
 
+    /**
+     * @return iterable<array{string, string, string}>
+     */
     public static function provideData(): iterable
     {
         yield [

--- a/tests/ReferenceVersionFinderTest.php
+++ b/tests/ReferenceVersionFinderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace staabm\PHPStanTodoBy\Tests;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\TestCase;
+use staabm\PHPStanTodoBy\ReferenceVersionFinder;
+use staabm\PHPStanTodoBy\TodoByDateRule;
+
+final class ReferenceVersionFinderTest extends TestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function testReferenceFinder(string $refernceVersion, string $staticTag, string $expected): void
+    {
+        $finder = new ReferenceVersionFinder($refernceVersion, new StaticTagFetcher($staticTag));
+        $this->assertSame($expected, $finder->find());
+    }
+
+    static public function provideData(): iterable
+    {
+        yield [
+            'nextMajor',
+            '1.0.3',
+            '2.0.0',
+        ];
+        yield [
+            'nextMinor',
+            '1.0.3',
+            '1.1.0',
+        ];
+        yield [
+            'nextPatch',
+            '1.0.3',
+            '1.0.4',
+        ];
+
+        yield [
+            'nextMajor',
+            '1.0',
+            '2.0.0',
+        ];
+        yield [
+            'nextMinor',
+            '1.0',
+            '1.1.0',
+        ];
+        yield [
+            'nextPatch',
+            '1.0',
+            '1.0.1',
+        ];
+
+        yield [
+            'nextMajor',
+            '1.0',
+            '2.0.0',
+        ];
+        yield [
+            'nextMinor',
+            '1.0',
+            '1.1.0',
+        ];
+        yield [
+            'nextPatch',
+            '1.0',
+            '1.0.1',
+        ];
+    }
+}

--- a/tests/utils/StaticTagFetcher.php
+++ b/tests/utils/StaticTagFetcher.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace staabm\PHPStanTodoBy\Tests;
+
+use staabm\PHPStanTodoBy\TagFetcher;
+
+final class StaticTagFetcher implements TagFetcher
+{
+    private string $tag;
+
+    public function __construct(string $tag) {
+        $this->tag = $tag;
+    }
+    public function fetchLatestTagVersion(): string
+    {
+        return $this->tag;
+    }
+}


### PR DESCRIPTION
before this PR we would get a exception for git tags with version `1.10` and similar (without a 3rd number)

```
  Internal error: Internal error: Version string '1.10' is not valid and cannot be parsed while analysing file                                                                 
     /Users/staabm/workspace/redaxo/redaxo/src/addons/diff_detect/lib/RssDiff.php                                                                                                 
                                                                                                                                                                                  
     Post the following stack trace to https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml:                                                                    
     ## /Users/staabm/workspace/redaxo/redaxo/src/addons/rexstan/vendor/nikolaposa/version/src/Exception/InvalidVersionString.php(16)                                             
     #0 /Users/staabm/workspace/redaxo/redaxo/src/addons/rexstan/vendor/nikolaposa/version/src/Version.php(65): Version\Exception\InvalidVersionString::notParsable('1.10')       
     #1 /Users/staabm/workspace/redaxo/redaxo/src/addons/rexstan/vendor/staabm/phpstan-todo-by/src/ReferenceVersionFinder.php(22): Version\Version::fromString('1.10')       
```