### PR TITLE
Show readable error when ticket doesn't exist

### DIFF
--- a/src/TodoByTicketRule.php
+++ b/src/TodoByTicketRule.php
@@ -74,7 +74,7 @@ final class TodoByTicketRule implements Rule
                 if (null === $ticketStatus) {
                     $errors[] = $this->errorBuilder->buildError(
                         $comment,
-                        "Ticket $ticketKey doesn't exist.",
+                        "Ticket $ticketKey doesn't exist or provided credentials do not allow for viewing it.",
                         null,
                         $match[0][1]
                     );

--- a/src/TodoByTicketRule.php
+++ b/src/TodoByTicketRule.php
@@ -71,7 +71,18 @@ final class TodoByTicketRule implements Rule
 
                 $ticketStatus = $this->fetcher->fetchTicketStatus($ticketKey);
 
-                if (null === $ticketStatus || !in_array($ticketStatus, $this->resolvedStatuses, true)) {
+                if (null === $ticketStatus) {
+                    $errors[] = $this->errorBuilder->buildError(
+                        $comment,
+                        "Ticket $ticketKey doesn't exist.",
+                        null,
+                        $match[0][1]
+                    );
+
+                    continue;
+                }
+
+                if (!in_array($ticketStatus, $this->resolvedStatuses, true)) {
                     continue;
                 }
 

--- a/src/utils/jira/JiraTicketStatusFetcher.php
+++ b/src/utils/jira/JiraTicketStatusFetcher.php
@@ -51,7 +51,12 @@ final class JiraTicketStatusFetcher implements TicketStatusFetcher
         ]);
 
         $response = curl_exec($curl);
-        if (!is_string($response) || 200 !== curl_getinfo($curl, CURLINFO_RESPONSE_CODE)) {
+
+        if (404 === $responseCode = curl_getinfo($curl, CURLINFO_RESPONSE_CODE)) {
+            return null;
+        }
+
+        if (!is_string($response) || 200 !== $responseCode) {
             throw new RuntimeException("Could not fetch ticket's status from Jira");
         }
 

--- a/tests/TodoByTicketRuleTest.php
+++ b/tests/TodoByTicketRuleTest.php
@@ -44,7 +44,7 @@ final class TodoByTicketRuleTest extends RuleTestCase
     public function testTicketNotFound(): void
     {
         $this->analyse([__DIR__ . '/data/ticket-not-found.php'], [
-            ["Ticket APP-000 doesn't exist.", 5],
+            ["Ticket APP-000 doesn't exist or provided credentials do not allow for viewing it.", 5],
         ]);
     }
 }

--- a/tests/TodoByTicketRuleTest.php
+++ b/tests/TodoByTicketRuleTest.php
@@ -40,4 +40,11 @@ final class TodoByTicketRuleTest extends RuleTestCase
             ['Should have been resolved in F01-12345: please change me.', 13],
         ]);
     }
+
+    public function testTicketNotFound(): void
+    {
+        $this->analyse([__DIR__ . '/data/ticket-not-found.php'], [
+            ["Ticket APP-000 doesn't exist.", 5],
+        ]);
+    }
 }

--- a/tests/data/ticket-not-found.php
+++ b/tests/data/ticket-not-found.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace TicketNotFound;
+
+// TODO APP-000

--- a/tests/data/ticket.php
+++ b/tests/data/ticket.php
@@ -7,7 +7,7 @@ function doFoo(): void {
     // TODO - APP-5000
 }
 
-// todo@user: APP-000 - fix it
+// todo@user: UNKNOWN-000 - fix it
 // @todo - APP-4444
 // todo - FOO-0001
 // TODO F01-12345 please change me


### PR DESCRIPTION
Currently, if the ticket doesn't exist, exception is thrown. This PR fixes this and now it's reported as normal error: `Ticket APP-000 doesn't exist.`

Please note that 404 is also returned by Jira if provided credentials do not allow for viewing the ticket even if it exists so it's not possible to distinguish these two reasons.