### PR TITLE
Allow using Jira issue tracker without credentials

### DIFF
--- a/src/utils/jira/JiraAuthorization.php
+++ b/src/utils/jira/JiraAuthorization.php
@@ -6,14 +6,14 @@ use RuntimeException;
 
 final class JiraAuthorization
 {
-    public static function getCredentials(?string $credentials, ?string $credentialsFilePath): string
+    public static function getCredentials(?string $credentials, ?string $credentialsFilePath): ?string
     {
         if (null !== $credentials) {
             return trim($credentials);
         }
 
         if (null === $credentialsFilePath) {
-            throw new RuntimeException('Either credentials or credentialsFilePath parameter must be configured');
+            return null;
         }
 
         $credentials = file_get_contents($credentialsFilePath);

--- a/src/utils/jira/JiraTicketStatusFetcher.php
+++ b/src/utils/jira/JiraTicketStatusFetcher.php
@@ -14,7 +14,7 @@ final class JiraTicketStatusFetcher implements TicketStatusFetcher
     private const API_VERSION = 2;
 
     private string $host;
-    private string $authorizationHeader;
+    private ?string $authorizationHeader;
 
     /**
      * @var array<string, ?string>
@@ -26,7 +26,7 @@ final class JiraTicketStatusFetcher implements TicketStatusFetcher
         $credentials = JiraAuthorization::getCredentials($credentials, $credentialsFilePath);
 
         $this->host = $host;
-        $this->authorizationHeader = JiraAuthorization::createAuthorizationHeader($credentials);
+        $this->authorizationHeader = $credentials ? JiraAuthorization::createAuthorizationHeader($credentials) : null;
 
         $this->cache = [];
     }
@@ -46,9 +46,12 @@ final class JiraTicketStatusFetcher implements TicketStatusFetcher
 
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, [
-            "Authorization: $this->authorizationHeader",
-        ]);
+
+        if (null !== $this->authorizationHeader) {
+            curl_setopt($curl, CURLOPT_HTTPHEADER, [
+                "Authorization: $this->authorizationHeader",
+            ]);
+        }
 
         $response = curl_exec($curl);
 

--- a/tests/jira/JiraAuthorizationTest.php
+++ b/tests/jira/JiraAuthorizationTest.php
@@ -3,7 +3,6 @@
 namespace staabm\PHPStanTodoBy\Tests\jira;
 
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use staabm\PHPStanTodoBy\utils\jira\JiraAuthorization;
 
 /**
@@ -11,12 +10,9 @@ use staabm\PHPStanTodoBy\utils\jira\JiraAuthorization;
  */
 final class JiraAuthorizationTest extends TestCase
 {
-    public function testThrowsIfNeitherCredentialsNorFilePathConfigured(): void
+    public function testReturnsNullIfNeitherCredentialsNorFilePathConfigured(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Either credentials or credentialsFilePath parameter must be configured');
-
-        JiraAuthorization::getCredentials(null, null);
+        static::assertNull(JiraAuthorization::getCredentials(null, null));
     }
 
     public function testCredentialsStringIsPreferredOverFilePath(): void


### PR DESCRIPTION
Public boards can be accessed without authentication so the developers shouldn't be forced to set credentials.