### PR TITLE
Ticket-rule: add "see $url" tip

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,17 +23,17 @@ jobs:
                         php-version: '8.2'
                         test-dir: tests-e2e/github/
                         script: |
-                            diff <(vendor/bin/phpstan analyse --error-format=raw --no-progress | sed "s|$(pwd)/||") expected-errors.txt
+                            diff -w <(vendor/bin/phpstan analyse --error-format=prettyJson --no-progress | sed "s|$(pwd)/||") expected-errors.json
                     -   os: ubuntu-latest
                         php-version: '8.2'
                         test-dir: tests-e2e/jira/
                         script: |
-                            diff <(vendor/bin/phpstan analyse --error-format=raw --no-progress | sed "s|$(pwd)/||") expected-errors.txt
+                            diff -w <(vendor/bin/phpstan analyse --error-format=prettyJson --no-progress | sed "s|$(pwd)/||") expected-errors.json
                     -   os: ubuntu-latest
                         php-version: '8.2'
                         test-dir: tests-e2e/youtrack/
                         script: |
-                            diff <(vendor/bin/phpstan analyse --error-format=raw --no-progress | sed "s|$(pwd)/||") expected-errors.txt
+                            diff -w <(vendor/bin/phpstan analyse --error-format=prettyJson --no-progress | sed "s|$(pwd)/||") expected-errors.json
 
         steps:
             -   name: Checkout

--- a/src/TodoByTicketRule.php
+++ b/src/TodoByTicketRule.php
@@ -101,7 +101,7 @@ final class TodoByTicketRule implements Rule
                     $errors[] = $this->errorBuilder->buildFileError(
                         $this->commentFromJson($json),
                         $errorMessage,
-                        null,
+                        "See {$this->configuration->getFetcher()->resolveTicketUrl($ticketKey)}",
                         $wholeMatchStartOffset,
                         $file,
                         $line

--- a/src/utils/ticket/GitHubTicketStatusFetcher.php
+++ b/src/utils/ticket/GitHubTicketStatusFetcher.php
@@ -38,13 +38,8 @@ final class GitHubTicketStatusFetcher implements TicketStatusFetcher
     {
         $ticketUrls = [];
 
-        $keyRegex = self::KEY_REGEX;
         foreach ($ticketKeys as $ticketKey) {
-            preg_match_all("/$keyRegex/ix", $ticketKey, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
-
-            $owner = $matches[0]['githubOwner'][0] ?: $this->defaultOwner;
-            $repo = $matches[0]['githubRepo'][0] ?: $this->defaultRepo;
-            $number = $matches[0]['githubNumber'][0];
+            [$owner, $repo, $number] = $this->processKey($ticketKey);
 
             $ticketUrls[$ticketKey] = "https://api.github.com/repos/$owner/$repo/issues/$number";
         }
@@ -90,5 +85,25 @@ final class GitHubTicketStatusFetcher implements TicketStatusFetcher
     public static function getKeyPattern(): string
     {
         return self::KEY_REGEX;
+    }
+
+    public function resolveTicketUrl(string $ticketKey): string
+    {
+        [$owner, $repo, $number] = $this->processKey($ticketKey);
+
+        return "https://github.com/$owner/$repo/issues/$number";
+    }
+
+    /** @return array{string,string,string} */
+    private function processKey(string $ticketKey): array
+    {
+        $keyRegex = self::KEY_REGEX;
+        preg_match_all("/$keyRegex/ix", $ticketKey, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
+        $owner = $matches[0]['githubOwner'][0] ?: $this->defaultOwner;
+        $repo = $matches[0]['githubRepo'][0] ?: $this->defaultRepo;
+        $number = $matches[0]['githubNumber'][0];
+
+        return [$owner, $repo, $number];
     }
 }

--- a/src/utils/ticket/JiraTicketStatusFetcher.php
+++ b/src/utils/ticket/JiraTicketStatusFetcher.php
@@ -73,6 +73,11 @@ final class JiraTicketStatusFetcher implements TicketStatusFetcher
         return '[A-Z0-9]+-\d+';
     }
 
+    public function resolveTicketUrl(string $ticketKey): string
+    {
+        return "$this->host/browse/$ticketKey";
+    }
+
     /** @return array{fields: array{status: array{name: string}}} */
     private static function decodeAndValidateResponse(string $body): array
     {

--- a/src/utils/ticket/TicketStatusFetcher.php
+++ b/src/utils/ticket/TicketStatusFetcher.php
@@ -14,4 +14,11 @@ interface TicketStatusFetcher
 
     /** @return non-empty-string */
     public static function getKeyPattern(): string;
+
+    /**
+     * @param non-empty-string $ticketKey
+     *
+     * @return non-empty-string
+     */
+    public function resolveTicketUrl(string $ticketKey): string;
 }

--- a/src/utils/ticket/YouTrackTicketStatusFetcher.php
+++ b/src/utils/ticket/YouTrackTicketStatusFetcher.php
@@ -64,6 +64,11 @@ final class YouTrackTicketStatusFetcher implements TicketStatusFetcher
         return '[A-Z0-9]+-\d+';
     }
 
+    public function resolveTicketUrl(string $ticketKey): string
+    {
+        return "https://youtrack.jetbrains.com/issue/$ticketKey";
+    }
+
     private static function createAuthorizationHeader(string $credentials): string
     {
         return "Bearer $credentials";

--- a/tests-e2e/github/expected-errors.json
+++ b/tests-e2e/github/expected-errors.json
@@ -1,0 +1,38 @@
+{
+    "totals": {
+        "errors": 0,
+        "file_errors": 4
+    },
+    "files": {
+        "src/github-issues-and-prs.php": {
+            "errors": 4,
+            "messages": [
+                {
+                    "message": "Should have been resolved in #59: fix me.",
+                    "line": 3,
+                    "ignorable": false,
+                    "tip": "See https://github.com/staabm/phpstan-todo-by/issues/59"
+                },
+                {
+                    "message": "Should have been resolved in staabm/phpstan-dba#452: change me after https://github.com/staabm/phpstan-dba/issues/452 is closed.",
+                    "line": 4,
+                    "ignorable": false,
+                    "tip": "See https://github.com/staabm/phpstan-dba/issues/452"
+                },
+                {
+                    "message": "Comment should have been resolved in phpstan/phpstan#3.",
+                    "line": 5,
+                    "ignorable": false,
+                    "tip": "See https://github.com/phpstan/phpstan/issues/3"
+                },
+                {
+                    "message": "Should have been resolved in #26: needs https://github.com/staabm/phpstan-todo-by/pull/26.",
+                    "line": 6,
+                    "ignorable": false,
+                    "tip": "See https://github.com/staabm/phpstan-todo-by/issues/26"
+                }
+            ]
+        }
+    },
+    "errors": []
+}

--- a/tests-e2e/github/expected-errors.txt
+++ b/tests-e2e/github/expected-errors.txt
@@ -1,4 +1,0 @@
-src/github-issues-and-prs.php:3:Should have been resolved in #59: fix me.
-src/github-issues-and-prs.php:4:Should have been resolved in staabm/phpstan-dba#452: change me after https://github.com/staabm/phpstan-dba/issues/452 is closed.
-src/github-issues-and-prs.php:5:Comment should have been resolved in phpstan/phpstan#3.
-src/github-issues-and-prs.php:6:Should have been resolved in #26: needs https://github.com/staabm/phpstan-todo-by/pull/26.

--- a/tests-e2e/jira/expected-errors.json
+++ b/tests-e2e/jira/expected-errors.json
@@ -1,0 +1,20 @@
+{
+    "totals": {
+        "errors": 0,
+        "file_errors": 1
+    },
+    "files": {
+        "src/tickets.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "Should have been resolved in JRA-9: fix me.",
+                    "line": 3,
+                    "ignorable": false,
+                    "tip": "See https://jira.atlassian.com/browse/JRA-9"
+                }
+            ]
+        }
+    },
+    "errors": []
+}

--- a/tests-e2e/jira/expected-errors.txt
+++ b/tests-e2e/jira/expected-errors.txt
@@ -1,1 +1,0 @@
-src/tickets.php:3:Should have been resolved in JRA-9: fix me.

--- a/tests-e2e/youtrack/expected-errors.json
+++ b/tests-e2e/youtrack/expected-errors.json
@@ -1,0 +1,20 @@
+{
+    "totals": {
+        "errors": 0,
+        "file_errors": 1
+    },
+    "files": {
+        "src/tickets.php": {
+            "errors": 1,
+            "messages": [
+                {
+                    "message": "Should have been resolved in WI-1: fix me.",
+                    "line": 3,
+                    "ignorable": false,
+                    "tip": "See https://youtrack.jetbrains.com/issue/WI-1"
+                }
+            ]
+        }
+    },
+    "errors": []
+}

--- a/tests-e2e/youtrack/expected-errors.txt
+++ b/tests-e2e/youtrack/expected-errors.txt
@@ -1,1 +1,0 @@
-src/tickets.php:3:Should have been resolved in WI-1: fix me.

--- a/tests/TodoByTicketRuleTest.php
+++ b/tests/TodoByTicketRuleTest.php
@@ -51,10 +51,26 @@ final class TodoByTicketRuleTest extends RuleTestCase
     public function testRule(): void
     {
         $this->analyse([__DIR__ . '/data/ticket.php'], [
-            ['Should have been resolved in APP-123: rename this to doBar().', 5],
-            ['Comment should have been resolved in APP-4444.', 11],
-            ['Comment should have been resolved in FOO-0001.', 12],
-            ['Should have been resolved in F01-12345: please change me.', 13],
+            [
+                'Should have been resolved in APP-123: rename this to doBar().',
+                5,
+                'See https://issue-tracker.com/APP-123',
+            ],
+            [
+                'Comment should have been resolved in APP-4444.',
+                11,
+                'See https://issue-tracker.com/APP-4444',
+            ],
+            [
+                'Comment should have been resolved in FOO-0001.',
+                12,
+                'See https://issue-tracker.com/FOO-0001',
+            ],
+            [
+                'Should have been resolved in F01-12345: please change me.',
+                13,
+                'See https://issue-tracker.com/F01-12345',
+            ],
         ]);
     }
 
@@ -71,10 +87,12 @@ final class TodoByTicketRuleTest extends RuleTestCase
             [
                 'Should have been resolved in F01-12345: please change me.',
                 9,
+                'See https://issue-tracker.com/F01-12345',
             ],
             [
                 'Should have been resolved in F01-12345: please * change me.',
                 13,
+                'See https://issue-tracker.com/F01-12345',
             ],
         ]);
     }

--- a/tests/utils/StaticTicketStatusFetcher.php
+++ b/tests/utils/StaticTicketStatusFetcher.php
@@ -36,4 +36,9 @@ final class StaticTicketStatusFetcher implements TicketStatusFetcher
     {
         return '[A-Z0-9]+-\d+';
     }
+
+    public function resolveTicketUrl(string $ticketKey): string
+    {
+        return "https://issue-tracker.com/$ticketKey";
+    }
 }


### PR DESCRIPTION
Implements #80 

This PR also changes how e2e tests assert expected errors, because the `raw` format did not include the tip. 