### PR TITLE
Allow referencing GitHub issues by `GH-` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ see examples of different comment variants which are supported:
 
 // TODO: APP-123 fix it when this Jira ticket is closed
 // TODO: #123 fix it when this GitHub issue is closed
+// TODO: GH-123 fix it when this GitHub issue is closed
 // TODO: some-organization/some-repo#123 change me if this GitHub pull request is closed
 ```
 
@@ -314,6 +315,7 @@ There are multiple ways to reference GitHub issue/PR:
 ##### Only number
 ```php
 // TODO: #123 - fix me
+// TODO: GH-123 - fix me
 ```
 If the `defaultOwner` is set to `acme` and `defaultRepo` is set to `hello-world`, the referenced issue is resolved to `acme/hello-world#123`.
 

--- a/src/utils/ticket/GitHubTicketStatusFetcher.php
+++ b/src/utils/ticket/GitHubTicketStatusFetcher.php
@@ -19,7 +19,7 @@ final class GitHubTicketStatusFetcher implements TicketStatusFetcher
     private const KEY_REGEX = '
           ((?P<githubOwner>[\w\-\.]+)\/)? # optional owner with slash separator
           (?P<githubRepo>[\w\-\.]+)? # optional repo
-          \#(?P<githubNumber>\d+) # ticket number
+          (\#|GH-)(?P<githubNumber>\d+) # ticket number
         ';
 
     private string $defaultOwner;

--- a/tests-e2e/github/expected-errors.json
+++ b/tests-e2e/github/expected-errors.json
@@ -1,11 +1,11 @@
 {
     "totals": {
         "errors": 0,
-        "file_errors": 4
+        "file_errors": 5
     },
     "files": {
         "src/github-issues-and-prs.php": {
-            "errors": 4,
+            "errors": 5,
             "messages": [
                 {
                     "message": "Should have been resolved in #59: fix me.",
@@ -33,6 +33,13 @@
                     "line": 6,
                     "ignorable": false,
                     "tip": "See https://github.com/staabm/phpstan-todo-by/issues/26",
+                    "identifier": "todoBy.ticket"
+                },
+                {
+                    "message": "Comment should have been resolved in GH-27.",
+                    "line": 7,
+                    "ignorable": false,
+                    "tip": "See https://github.com/staabm/phpstan-todo-by/issues/27",
                     "identifier": "todoBy.ticket"
                 }
             ]

--- a/tests-e2e/github/src/github-issues-and-prs.php
+++ b/tests-e2e/github/src/github-issues-and-prs.php
@@ -4,3 +4,4 @@
 // TODO: staabm/phpstan-dba#452 - change me after https://github.com/staabm/phpstan-dba/issues/452 is closed
 // TODO: phpstan/phpstan#3
 // TODO: #26 - needs https://github.com/staabm/phpstan-todo-by/pull/26
+// TODO: GH-27


### PR DESCRIPTION
GitHub supports referencing issues / PRs by `GH-123` which is essentially the same as `#123` which the extension currently supports. This PR adds support for detecting expired comments when issues are references by this prefix.  

See: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests