### PR TITLE
Fix bug when same GitHub issue is referenced in multiple ways

### DIFF
--- a/src/utils/ticket/GitHubTicketStatusFetcher.php
+++ b/src/utils/ticket/GitHubTicketStatusFetcher.php
@@ -78,7 +78,12 @@ final class GitHubTicketStatusFetcher implements TicketStatusFetcher
         $responses = $this->httpClient->getMulti($ticketUrls, $headers);
 
         $results = [];
-        $urlsToKeys = array_flip($ticketUrls);
+
+        $urlsToKeys = [];
+        foreach ($ticketUrls as $key => $url) {
+            $urlsToKeys[$url][] = $key;
+        }
+
         foreach ($responses as $url => [$responseCode, $response]) {
             if (404 === $responseCode) {
                 $results[$url] = null;
@@ -94,8 +99,9 @@ final class GitHubTicketStatusFetcher implements TicketStatusFetcher
                 throw new RuntimeException("GitHub returned invalid response body with $url");
             }
 
-            $ticketKey = $urlsToKeys[$url];
-            $results[$ticketKey] = $data['state'];
+            foreach ($urlsToKeys[$url] as $ticketKey) {
+                $results[$ticketKey] = $data['state'];
+            }
         }
 
         return $results;

--- a/tests-e2e/github/expected-errors.json
+++ b/tests-e2e/github/expected-errors.json
@@ -1,11 +1,11 @@
 {
     "totals": {
         "errors": 0,
-        "file_errors": 5
+        "file_errors": 6
     },
     "files": {
         "src/github-issues-and-prs.php": {
-            "errors": 5,
+            "errors": 6,
             "messages": [
                 {
                     "message": "Should have been resolved in #59: fix me.",
@@ -40,6 +40,13 @@
                     "line": 7,
                     "ignorable": false,
                     "tip": "See https://github.com/staabm/phpstan-todo-by/issues/27",
+                    "identifier": "todoBy.ticket"
+                },
+                {
+                    "message": "Comment should have been resolved in staabm/phpstan-todo-by#59.",
+                    "line": 8,
+                    "ignorable": false,
+                    "tip": "See https://github.com/staabm/phpstan-todo-by/issues/59",
                     "identifier": "todoBy.ticket"
                 }
             ]

--- a/tests-e2e/github/src/github-issues-and-prs.php
+++ b/tests-e2e/github/src/github-issues-and-prs.php
@@ -5,3 +5,4 @@
 // TODO: phpstan/phpstan#3
 // TODO: #26 - needs https://github.com/staabm/phpstan-todo-by/pull/26
 // TODO: GH-27
+// TODO: staabm/phpstan-todo-by#59


### PR DESCRIPTION
Currently in case of GitHub there are multiple ways we can use to reference the same issue. This PR fixes runtime exception (`Missing ticket-status for key #59`) that was thrown in this situation.
