### PR TITLE
Ignore InlineHTML to reduce memory consumption

### DIFF
--- a/src/utils/CommentMatcher.php
+++ b/src/utils/CommentMatcher.php
@@ -19,6 +19,7 @@ final class CommentMatcher
         if (
             $node instanceof VirtualNode
             || $node instanceof Node\Expr
+            || $node instanceof Node\Stmt\InlineHTML
             || $node instanceof \PHPStan\Node\CollectedDataNode // see https://github.com/phpstan/phpstan/discussions/11701
         ) {
             // prevent duplicate errors

--- a/tests/TodoByDateRuleTest.php
+++ b/tests/TodoByDateRuleTest.php
@@ -201,4 +201,17 @@ final class TodoByDateRuleTest extends RuleTestCase
             ],
         ]);
     }
+
+    public function testInlineHtml(): void
+    {
+        $this->referenceTime = 'now';
+
+        $this->analyse([__DIR__ . '/data/inline-html.php'], [
+            [
+                'Expired on 2023-12-14: Expired comment1.',
+                8
+            ]
+        ]);
+    }
+
 }

--- a/tests/data/inline-html.php
+++ b/tests/data/inline-html.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ExampleTest;
+namespace InlineHtmlTest;
 
 ?>
 <head></head>

--- a/tests/data/inline-html.php
+++ b/tests/data/inline-html.php
@@ -6,6 +6,5 @@ namespace ExampleTest;
 <head></head>
 <?php
 // TODO: 2023-12-14 Expired comment1
-// TODO 2023-12-14 Expired comment2
 ?>
 <h1>hello</h1>

--- a/tests/data/inline-html.php
+++ b/tests/data/inline-html.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ExampleTest;
+
+?>
+<head></head>
+<?php
+// TODO: 2023-12-14 Expired comment1
+// TODO 2023-12-14 Expired comment2
+?>
+<h1>hello</h1>


### PR DESCRIPTION
comments in inline html are not carried with the InlineHtml node but a `Nop` node before.
so we can stop looking at `InlineHtml` nodes, to prevent unnecessary work

![grafik](https://github.com/user-attachments/assets/61c29973-737c-44c4-8ffc-308b70f037ec)

refs https://github.com/staabm/phpstan-todo-by/issues/103
